### PR TITLE
Exposed block breakable option

### DIFF
--- a/src/util/basic-tool.typ
+++ b/src/util/basic-tool.typ
@@ -463,7 +463,7 @@
 /// Define border arguments for styling.
 ///
 /// -> any
-#let border-args = ("stroke", "radius", "outset", "fill", "inset", "clip")
+#let border-args = ("stroke", "radius", "outset", "fill", "inset", "clip", "breakable")
 
 
 /// Parse the body format with additional parameters.


### PR DESCRIPTION
After some narrowing down, I found that the parse-body-format-with function was suppressing the breakable option as it was not in this list of styling keys.

Now you can use body-format: outer: breakable to determine whether an item in the default-enum-list format is breakable.

This closes #12 